### PR TITLE
CORCI-918 build: Add maldetect download

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,17 @@ pipeline {
                   }
                 } // post
             } // stage ('bullshtml')
+            stage ('maldetect') {
+                steps {
+                    sh script: './get_maldetect.sh',
+                       label: 'Get maldetect'
+                }
+                post {
+                  success {
+                      archiveArtifacts artifacts: 'maldetect-current.tar.gz'
+                  }
+                } // post
+            } // stage ('maldetect')
         } // parallel
         } // stage ('tools')
     } // stages

--- a/get_bullseye.sh
+++ b/get_bullseye.sh
@@ -28,5 +28,8 @@ if [ ! -e "${dnl_fname}" ]; then
     "${bullseye_url}/${dnl_fname}" -O
 fi
 
+# sanity check to make sure we have a good tarball
+tar -tf "${dnl_fname}" > /dev/null
+
 rm -f ./bullseyecoverage-linux.tar
 ln "${dnl_fname}" ./bullseyecoverage-linux.tar

--- a/get_bullshtml.sh
+++ b/get_bullshtml.sh
@@ -26,3 +26,6 @@ fi
 
 rm -f ./bullshtml.jar
 cp bullshtml/build/libs/bullshtml-*.jar ./bullshtml.jar
+
+# Make sure we got a valid jar
+unzip -t ./bullshtml.jar > /dev/null

--- a/get_maldetect.sh
+++ b/get_maldetect.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -uex
+
+lmd_tarball='maldetect-current.tar.gz'
+
+curl "http://rfxn.com/downloads/${lmd_tarball}" \
+  -z "${lmd_tarball}"  --silent --show-error --fail -O
+
+# sanity check to make sure we have a good tarball
+tar -tf "${lmd_tarball}" > /dev/null

--- a/get_maldetect.sh
+++ b/get_maldetect.sh
@@ -5,7 +5,8 @@ set -uex
 lmd_tarball='maldetect-current.tar.gz'
 
 curl "http://rfxn.com/downloads/${lmd_tarball}" \
-  -z "${lmd_tarball}"  --silent --show-error --fail -O
+  -z "${lmd_tarball}" --retry 10 --retry-max-time 60 --silent --show-error \
+  --fail -O
 
 # sanity check to make sure we have a good tarball
 tar -tf "${lmd_tarball}" > /dev/null


### PR DESCRIPTION
The maldetect download is used for malware scans and is not available
as an RPM.

Also add sanity checks to make sure that the artifacts are at
least valid jars or tarballs.

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>